### PR TITLE
Add `timeout` function to `anemo::Request`

### DIFF
--- a/crates/anemo/src/middleware/timeout/mod.rs
+++ b/crates/anemo/src/middleware/timeout/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod outbound;
 /// the value we attempted to parse.
 ///
 /// The value of the `timeout` header is expected to in nanoseconds encoded encoded as an u64
-fn try_parse_timeout(headers: &HeaderMap) -> Result<Option<Duration>, &str> {
+pub(crate) fn try_parse_timeout(headers: &HeaderMap) -> Result<Option<Duration>, &str> {
     match headers.get(header::TIMEOUT) {
         Some(val) => {
             let nanoseconds = val.parse::<u64>().map_err(|_| val.as_ref())?;

--- a/crates/anemo/src/types/request.rs
+++ b/crates/anemo/src/types/request.rs
@@ -210,6 +210,29 @@ impl<T> Request<T> {
         self.set_timeout(timeout);
         self
     }
+
+    /// Returns the previously-set timeout on this Request, or None if
+    /// not set or invalid.
+    ///
+    /// Example:
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    /// use anemo::Request;
+    ///
+    /// let request = Request::new(()).with_timeout(Duration::from_secs(30));
+    /// let timeout = request.timeout().unwrap();
+    ///
+    /// assert_eq!(
+    ///     timeout,
+    ///     Duration::from_secs(30),
+    /// );
+    /// ```
+    pub fn timeout(&self) -> Option<std::time::Duration> {
+        crate::middleware::timeout::try_parse_timeout(self.headers())
+            .ok()
+            .flatten()
+    }
 }
 
 pub trait IntoRequest<T> {


### PR DESCRIPTION
Retrieves previously-set timeout.