### PR TITLE
Pin GitHub Actions in workflows to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
   pull_request:
 
+
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: -D warnings
@@ -14,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # pin@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           components: rustfmt, clippy

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # pin@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
@@ -22,7 +22,7 @@ jobs:
         run: cargo doc --no-deps
 
       - name: Deploy Docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935 # pin@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages


### PR DESCRIPTION
Used [mheap/pin-github-action](https://github.com/mheap/pin-github-action) to update the workfows in `.github/workflows/*.yml`

The utility updates the actions in the workflow to the specific SHA commit referenced at that particular version. It leaves the specific version pinned as a comment alongside the action.

This change follows best practices documented by:
* [GitHub](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
* [OpenSSF](https://github.com/ossf/scorecard/blob/7206a2bdeb7020ab45744a1a6234c9ddf2f3713c/docs/checks.md#pinned-dependencies)