### PR TITLE
Emit failure events at WARN level

### DIFF
--- a/crates/anemo-tower/src/trace/mod.rs
+++ b/crates/anemo-tower/src/trace/mod.rs
@@ -283,7 +283,7 @@ mod on_response;
 mod service;
 
 const DEFAULT_MESSAGE_LEVEL: Level = Level::DEBUG;
-const DEFAULT_ERROR_LEVEL: Level = Level::ERROR;
+const DEFAULT_FAILURE_LEVEL: Level = Level::WARN;
 
 #[cfg(test)]
 mod tests {

--- a/crates/anemo-tower/src/trace/on_failure.rs
+++ b/crates/anemo-tower/src/trace/on_failure.rs
@@ -1,4 +1,4 @@
-use super::{super::LatencyUnit, DEFAULT_ERROR_LEVEL};
+use super::{super::LatencyUnit, DEFAULT_FAILURE_LEVEL};
 use std::time::Duration;
 use tracing::{Level, Span};
 
@@ -49,7 +49,7 @@ pub struct DefaultOnFailure {
 impl Default for DefaultOnFailure {
     fn default() -> Self {
         Self {
-            level: DEFAULT_ERROR_LEVEL,
+            level: DEFAULT_FAILURE_LEVEL,
             latency_unit: LatencyUnit::Millis,
         }
     }


### PR DESCRIPTION
Otherwise, expected failures logging at ERROR level can make true failures harder to observe.