### PR TITLE
add timeout during shutdown

### DIFF
--- a/crates/anemo/src/config.rs
+++ b/crates/anemo/src/config.rs
@@ -112,6 +112,13 @@ pub struct Config {
     /// In unspecified, no default timeout will be configured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub outbound_request_timeout_ms: Option<u64>,
+
+    /// Set a timeout, in milliseconds, until the peers are notified when network
+    /// is shutting down
+    ///
+    /// If unspecified, then this will default to 1 minute (60 * 1_000 ms)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shutdown_idle_timeout_ms: Option<u64>,
 }
 
 /// Configuration for the underlying QUIC transport.
@@ -228,6 +235,14 @@ impl Config {
 
     pub(crate) fn outbound_request_timeout(&self) -> Option<Duration> {
         self.outbound_request_timeout_ms.map(Duration::from_millis)
+    }
+
+    pub(crate) fn shutdown_idle_timeout(&self) -> Duration {
+        const DEFAULT_SHUTDOWN_IDLE_TIMEOUT_MS: u64 = 60_000; // 1 minute
+
+        self.shutdown_idle_timeout_ms
+            .map(Duration::from_millis)
+            .unwrap_or(Duration::from_millis(DEFAULT_SHUTDOWN_IDLE_TIMEOUT_MS))
     }
 }
 

--- a/crates/anemo/src/network/connection_manager.rs
+++ b/crates/anemo/src/network/connection_manager.rs
@@ -185,7 +185,9 @@ impl ConnectionManager {
         );
 
         // wait for the endpoint to be idle
-        self.endpoint.wait_idle().await;
+        self.endpoint
+            .wait_idle(self.config.shutdown_idle_timeout())
+            .await;
 
         // This is a small hack in order to ensure that the underlying socket we're bound to is
         // dropped and immediately available to be rebound to once this function exits.


### PR DESCRIPTION
Add the ability to configure a timeout to be used with the wait_idle method to designate the maximum time we want to wait until connections become idle.