### PR TITLE
Expose stream send and receive buffer sizes via `QuicConfig`

### DIFF
--- a/crates/anemo/src/config.rs
+++ b/crates/anemo/src/config.rs
@@ -142,6 +142,32 @@ pub struct QuicConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_concurrent_uni_streams: Option<u64>,
 
+    /// Maximum number of bytes a peer may transmit without acknowledgement on any one stream
+    /// before becoming blocked.
+    ///
+    /// If unspecified, this will default to 1.25MB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream_receive_window: Option<u64>,
+
+    /// Maximum number of bytes a peer may transmit across all streams of a connection before
+    /// becoming blocked.
+    ///
+    /// If unspecified, this will default to unlimited.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    receive_window: Option<u64>,
+
+    /// Maximum number of bytes to transmit to a peer without acknowledgment
+    ///
+    /// If unspecified, this will default to 10MB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    send_window: Option<u64>,
+
+    /// Maximum quantity of out-of-order crypto layer data to buffer
+    ///
+    /// If unspecified, this will default to 16KiB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    crypto_buffer_size: Option<usize>,
+
     /// How long to wait to hear from a peer before timing out a connection.
     ///
     /// In the absence of any keep-alive messages, connections will be closed if they remain idle
@@ -250,16 +276,6 @@ impl QuicConfig {
     pub(crate) fn transport_config(&self) -> quinn::TransportConfig {
         let mut config = quinn::TransportConfig::default();
 
-        // 50MB per stream.
-        const STREAM_RWND: u64 = 50 << 20;
-        // Assume committee size of 200.
-        const NUM_STREAMS: u64 = 200;
-
-        config.stream_receive_window((STREAM_RWND).try_into().unwrap());
-        config.receive_window((NUM_STREAMS * STREAM_RWND).try_into().unwrap());
-        config.send_window(NUM_STREAMS * STREAM_RWND);
-        config.crypto_buffer_size(1 << 20);
-
         if let Some(max) = self
             .max_concurrent_bidi_streams
             .map(|n| VarInt::try_from(n).unwrap_or(VarInt::MAX))
@@ -272,6 +288,28 @@ impl QuicConfig {
             .map(|n| VarInt::try_from(n).unwrap_or(VarInt::MAX))
         {
             config.max_concurrent_uni_streams(max);
+        }
+
+        if let Some(max) = self
+            .stream_receive_window
+            .map(|n| VarInt::try_from(n).unwrap_or(VarInt::MAX))
+        {
+            config.stream_receive_window(max);
+        }
+
+        if let Some(max) = self
+            .receive_window
+            .map(|n| VarInt::try_from(n).unwrap_or(VarInt::MAX))
+        {
+            config.receive_window(max);
+        }
+
+        if let Some(n) = self.send_window {
+            config.send_window(n);
+        }
+
+        if let Some(n) = self.crypto_buffer_size {
+            config.crypto_buffer_size(n);
         }
 
         if let Some(max) = self

--- a/crates/anemo/src/config.rs
+++ b/crates/anemo/src/config.rs
@@ -250,6 +250,16 @@ impl QuicConfig {
     pub(crate) fn transport_config(&self) -> quinn::TransportConfig {
         let mut config = quinn::TransportConfig::default();
 
+        // 50MB per stream.
+        const STREAM_RWND: u64 = 50 << 20;
+        // Assume committee size of 200.
+        const NUM_STREAMS: u64 = 200;
+
+        config.stream_receive_window((STREAM_RWND).try_into().unwrap());
+        config.receive_window((NUM_STREAMS * STREAM_RWND).try_into().unwrap());
+        config.send_window(NUM_STREAMS * STREAM_RWND);
+        config.crypto_buffer_size(1 << 20);
+
         if let Some(max) = self
             .max_concurrent_bidi_streams
             .map(|n| VarInt::try_from(n).unwrap_or(VarInt::MAX))


### PR DESCRIPTION
Right now we are using the [default values](https://github.com/quinn-rs/quinn/blob/02037e72fa6b7f994a2db411977bcffacbb8b02c/quinn-proto/src/config.rs#L251-L278) of following fields in `quinn::TransportConfig`:
- `stream_receive_window` at 1.25MB
- `receive_window` at unlimited
- `send_window` at 10MB
- `crypto_buffer_size` at 16KiB

They seem too low for the use case of 100+ validators with a lot of CPU and memory transferring data to each other. Increasing them has shown to increase throughput.

This commit updates the default values. I can also make these parameters configurable via anemo Config, or expose them as expected RTT, bytes throughput and # of peers. LMK how you want to configure these values.