### PR TITLE
Add support for server handlers returning serialized raw bytes

### DIFF
--- a/crates/anemo-build/src/manual.rs
+++ b/crates/anemo-build/src/manual.rs
@@ -176,6 +176,8 @@ pub struct Method {
     response_type: String,
     /// The path to the codec to use for this method
     codec_path: String,
+    /// Use raw (serialized) bytes for the server-side response handler.
+    server_handler_use_raw_bytes: bool,
 }
 
 impl Method {
@@ -210,6 +212,10 @@ impl Method {
         syn::parse_str::<syn::Type>(&self.response_type)
             .unwrap()
             .to_token_stream()
+    }
+
+    pub fn server_handler_use_raw_bytes(&self) -> bool {
+        self.server_handler_use_raw_bytes
     }
 }
 
@@ -246,6 +252,8 @@ pub struct MethodBuilder {
     response_type: Option<String>,
     /// The path to the codec to use for this method
     codec_path: Option<String>,
+    /// Use raw (serialized) bytes for the server-side response handler.
+    server_handler_use_raw_bytes: bool,
 }
 
 impl MethodBuilder {
@@ -296,6 +304,12 @@ impl MethodBuilder {
         self
     }
 
+    /// Set whether or not the server handler should use raw bytes for the response.
+    pub fn server_handler_use_raw_bytes(mut self, use_raw_bytes: bool) -> Self {
+        self.server_handler_use_raw_bytes = use_raw_bytes;
+        self
+    }
+
     /// Build a Method
     ///
     /// Panics if `name`, `route_name`, `request_type`, `response_type`, or `codec_path` weren't set.
@@ -307,6 +321,7 @@ impl MethodBuilder {
             request_type: self.request_type.unwrap(),
             response_type: self.response_type.unwrap(),
             codec_path: self.codec_path.unwrap(),
+            server_handler_use_raw_bytes: self.server_handler_use_raw_bytes,
         }
     }
 }

--- a/crates/anemo-build/src/manual.rs
+++ b/crates/anemo-build/src/manual.rs
@@ -177,7 +177,7 @@ pub struct Method {
     /// The path to the codec to use for this method
     codec_path: String,
     /// Use raw (serialized) bytes for the server-side response handler.
-    server_handler_use_raw_bytes: bool,
+    server_handler_return_raw_bytes: bool,
 }
 
 impl Method {
@@ -214,8 +214,8 @@ impl Method {
             .to_token_stream()
     }
 
-    pub fn server_handler_use_raw_bytes(&self) -> bool {
-        self.server_handler_use_raw_bytes
+    pub fn server_handler_return_raw_bytes(&self) -> bool {
+        self.server_handler_return_raw_bytes
     }
 }
 
@@ -253,7 +253,7 @@ pub struct MethodBuilder {
     /// The path to the codec to use for this method
     codec_path: Option<String>,
     /// Use raw (serialized) bytes for the server-side response handler.
-    server_handler_use_raw_bytes: bool,
+    server_handler_return_raw_bytes: bool,
 }
 
 impl MethodBuilder {
@@ -305,8 +305,8 @@ impl MethodBuilder {
     }
 
     /// Set whether or not the server handler should use raw bytes for the response.
-    pub fn server_handler_use_raw_bytes(mut self, use_raw_bytes: bool) -> Self {
-        self.server_handler_use_raw_bytes = use_raw_bytes;
+    pub fn server_handler_return_raw_bytes(mut self, use_raw_bytes: bool) -> Self {
+        self.server_handler_return_raw_bytes = use_raw_bytes;
         self
     }
 
@@ -321,7 +321,7 @@ impl MethodBuilder {
             request_type: self.request_type.unwrap(),
             response_type: self.response_type.unwrap(),
             codec_path: self.codec_path.unwrap(),
-            server_handler_use_raw_bytes: self.server_handler_use_raw_bytes,
+            server_handler_return_raw_bytes: self.server_handler_return_raw_bytes,
         }
     }
 }

--- a/crates/anemo-build/src/server.rs
+++ b/crates/anemo-build/src/server.rs
@@ -28,7 +28,13 @@ pub fn generate(service: &Service) -> TokenStream {
     let method_response_types: Vec<_> = service
         .methods()
         .iter()
-        .map(|method| method.response_type())
+        .map(|method| {
+            if method.server_handler_use_raw_bytes() {
+                quote! { bytes::Bytes }
+            } else {
+                method.response_type()
+            }
+        })
         .collect();
     let add_layer_function_names: Vec<_> = service
         .methods()
@@ -176,7 +182,11 @@ fn generate_trait_methods(service: &Service) -> TokenStream {
         let name = quote::format_ident!("{}", method.name());
 
         let request = method.request_type();
-        let response = method.response_type();
+        let response = if method.server_handler_use_raw_bytes() {
+            quote! { bytes::Bytes }
+        } else {
+            method.response_type()
+        };
 
         let method_doc = generate_doc_comments(method.comment());
 
@@ -223,7 +233,11 @@ fn generate_method_service(method: &Method, server_trait: Ident) -> TokenStream 
     let service_ident = quote::format_ident!("{}Svc", method.identifier());
 
     let request = method.request_type();
-    let response = method.response_type();
+    let response = if method.server_handler_use_raw_bytes() {
+        quote! { bytes::Bytes }
+    } else {
+        method.response_type()
+    };
 
     quote! {
         #[allow(non_camel_case_types)]
@@ -291,17 +305,33 @@ fn generate_method_routes(service: &Service) -> TokenStream {
 fn generate_method_route(method: &Method) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
 
+    let response_type = method.response_type();
+    let request_type = method.request_type();
+
     let layer_name = quote::format_ident!("{}_layer", method.name());
     let service_ident = quote::format_ident!("{}Svc", method.identifier());
+
+    let codec_init = if method.server_handler_use_raw_bytes() {
+        quote! {
+            let request_codec = #codec_name::<#response_type, #request_type>::default();
+            let response_codec =
+                anemo::rpc::codec::IdentityCodec::new(request_codec.format_name());
+        }
+    } else {
+        quote! {
+            let request_codec = #codec_name::default();
+            let response_codec = #codec_name::default();
+        }
+    };
 
     quote! {
         let inner = self.inner.clone();
         let layer = self.#layer_name.clone();
         let fut = async move {
             let method = layer.layer(BoxCloneService::new(#service_ident(inner)));
-            let codec = #codec_name::default();
+            #codec_init
 
-            let mut rpc = anemo::rpc::server::Rpc::new(codec);
+            let mut rpc = anemo::rpc::server::Rpc::new(request_codec, response_codec);
 
             let res = rpc.unary(method, req).await;
             Ok(res)

--- a/crates/anemo-build/src/server.rs
+++ b/crates/anemo-build/src/server.rs
@@ -29,7 +29,7 @@ pub fn generate(service: &Service) -> TokenStream {
         .methods()
         .iter()
         .map(|method| {
-            if method.server_handler_use_raw_bytes() {
+            if method.server_handler_return_raw_bytes() {
                 quote! { bytes::Bytes }
             } else {
                 method.response_type()
@@ -182,7 +182,7 @@ fn generate_trait_methods(service: &Service) -> TokenStream {
         let name = quote::format_ident!("{}", method.name());
 
         let request = method.request_type();
-        let response = if method.server_handler_use_raw_bytes() {
+        let response = if method.server_handler_return_raw_bytes() {
             quote! { bytes::Bytes }
         } else {
             method.response_type()
@@ -233,7 +233,7 @@ fn generate_method_service(method: &Method, server_trait: Ident) -> TokenStream 
     let service_ident = quote::format_ident!("{}Svc", method.identifier());
 
     let request = method.request_type();
-    let response = if method.server_handler_use_raw_bytes() {
+    let response = if method.server_handler_return_raw_bytes() {
         quote! { bytes::Bytes }
     } else {
         method.response_type()
@@ -311,7 +311,7 @@ fn generate_method_route(method: &Method) -> TokenStream {
     let layer_name = quote::format_ident!("{}_layer", method.name());
     let service_ident = quote::format_ident!("{}Svc", method.identifier());
 
-    let codec_init = if method.server_handler_use_raw_bytes() {
+    let codec_init = if method.server_handler_return_raw_bytes() {
         quote! {
             let request_codec = #codec_name::<#response_type, #request_type>::default();
             let response_codec =

--- a/crates/anemo/src/lib.rs
+++ b/crates/anemo/src/lib.rs
@@ -21,8 +21,8 @@ pub use async_trait::async_trait;
 #[doc(hidden)]
 pub mod codegen {
     pub use super::{
-        error::BoxError, middleware::box_clone_layer::BoxCloneLayer, types::response::IntoResponse,
-        Request, Response,
+        error::BoxError, middleware::box_clone_layer::BoxCloneLayer, rpc::codec::Codec,
+        types::response::IntoResponse, Request, Response,
     };
     pub use async_trait::async_trait;
     pub use bytes::Bytes;

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -11,6 +11,8 @@ serde = { version = "1.0.142", features = ["derive"] }
 anemo = { path = "../anemo" }
 anemo-cli = { path = "../anemo-cli" }
 anemo-tower = { path = "../anemo-tower" }
+bincode = "1.3.3"
+bytes = { version = "1.1.0", features = ["serde"] }
 tokio = { version = "1.20.1", features = ["full"] }
 tower = { version = "0.4.12", default-features = false, features = ["full"] }
 futures = "0.3.21"

--- a/crates/examples/build.rs
+++ b/crates/examples/build.rs
@@ -10,6 +10,7 @@ fn main() {
                 .response_type("crate::HelloResponse")
                 .codec_path("anemo::rpc::codec::BincodeCodec")
                 // .codec_path("anemo::rpc::codec::JsonCodec")
+                .server_handler_use_raw_bytes(true)
                 .build(),
         )
         .build();

--- a/crates/examples/build.rs
+++ b/crates/examples/build.rs
@@ -10,7 +10,7 @@ fn main() {
                 .response_type("crate::HelloResponse")
                 .codec_path("anemo::rpc::codec::BincodeCodec")
                 // .codec_path("anemo::rpc::codec::JsonCodec")
-                .server_handler_use_raw_bytes(true)
+                .server_handler_return_raw_bytes(true)
                 .build(),
         )
         .build();

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -40,7 +40,7 @@ impl Greeter for MyGreeter {
         };
 
         // Manually serializing the response here to show an example of a server handler using
-        // the `server_handler_use_raw_bytes` option.
+        // the `server_handler_return_raw_bytes` option.
         let mut reply_bytes = bytes::BytesMut::new();
         bincode::serialize_into(reply_bytes.as_mut().writer(), &reply)
             .map_err(|e| anemo::rpc::Status::from_error(e.into()))?;

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -1,4 +1,5 @@
 use anemo::{rpc::Status, Request, Response};
+use bytes::BufMut;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -28,7 +29,7 @@ impl Greeter for MyGreeter {
     async fn say_hello(
         &self,
         request: Request<HelloRequest>,
-    ) -> Result<Response<HelloResponse>, Status> {
+    ) -> Result<Response<bytes::Bytes>, Status> {
         info!(
             "Got a request from {}",
             request.peer_id().unwrap().short_display(4)
@@ -37,6 +38,12 @@ impl Greeter for MyGreeter {
         let reply = HelloResponse {
             message: format!("Hello {}!", request.into_body().name),
         };
-        Ok(Response::new(reply))
+
+        // Manually serializing the response here to show an example of a server handler using
+        // the `server_handler_use_raw_bytes` option.
+        let mut reply_bytes = bytes::BytesMut::new();
+        bincode::serialize_into(reply_bytes.as_mut().writer(), &reply)
+            .map_err(|e| anemo::rpc::Status::from_error(e.into()))?;
+        Ok(Response::new(reply_bytes.freeze()))
     }
 }


### PR DESCRIPTION
- Adds an `IdentityCodec`
- Adds a `server_handler_use_raw_bytes` option to code generation