### PR TITLE
add allowlisted affinity

### DIFF
--- a/crates/anemo/src/config.rs
+++ b/crates/anemo/src/config.rs
@@ -60,18 +60,19 @@ pub struct Config {
     /// Maximum number of concurrent connections to have established at a given point in time.
     ///
     /// This limit is applied in the following ways:
-    ///  - Inbound connections from [`KnownPeers`] with [`PeerAffinity::High`] bypass this limit. All
-    ///  other inbound connections are only accepted if the total number of inbound and outbound
+    ///  - Inbound connections from [`KnownPeers`] with [`PeerAffinity::High`] or
+    /// [`PeerAffinity::Allowed`] bypass this limit. All other inbound
+    ///  connections are only accepted if the total number of inbound and outbound
     ///  connections, irrespective of affinity, is less than this limit.
     ///  - Outbound connections explicitly made by the application via [`Network::connect`] or
     ///  [`Network::connect_with_peer_id`] bypass this limit.
     ///  - Outbound connections made in the background, due to configured [`KnownPeers`], to peers with
-    ///  [`PeerAffinity::High`] bypass this limit and are always attempted, while peers with lower
-    ///  affinity respect this limit.
+    ///  [`PeerAffinity::High`] bypass this limit and are always attempted.
     ///
     /// If unspecified, there will be no limit on the number of concurrent connections.
     ///
     /// [`KnownPeers`]: crate::KnownPeers
+    /// [`PeerAffinity::Allowed`]: crate::types::PeerAffinity::Allowed
     /// [`PeerAffinity::High`]: crate::types::PeerAffinity::High
     /// [`Network::connect`]: crate::Network::connect
     /// [`Network::connect_with_peer_id`]: crate::Network::connect_with_peer_id
@@ -501,6 +502,7 @@ impl EndpointConfigBuilder {
         Ok(server)
     }
 
+    #[allow(deprecated)]
     fn client_config(
         cert: rustls::Certificate,
         pkcs8_der: rustls::PrivateKey,
@@ -561,6 +563,7 @@ impl EndpointConfig {
         &self.quinn_client_config
     }
 
+    #[allow(deprecated)]
     pub fn client_config_with_expected_server_identity(
         &self,
         peer_id: PeerId,

--- a/crates/anemo/src/config.rs
+++ b/crates/anemo/src/config.rs
@@ -563,6 +563,10 @@ impl EndpointConfig {
         &self.quinn_client_config
     }
 
+    // TODO: remove #[allow(deprecated)] once we upgrade rustls
+    // to 0.21.4 or above, where `with_single_cert` is marked as
+    // deprecated. Before that happens, we use the attribute to
+    // keep clippy happy.
     #[allow(deprecated)]
     pub fn client_config_with_expected_server_identity(
         &self,

--- a/crates/anemo/src/network/connection_manager.rs
+++ b/crates/anemo/src/network/connection_manager.rs
@@ -250,7 +250,9 @@ impl ConnectionManager {
             // TODO close the connection explicitly with a reason once we have machine
             // readable errors. See https://github.com/MystenLabs/anemo/issues/13 for more info.
             match known_peers.get(&connection.peer_id()) {
-                Some(PeerInfo { affinity, .. }) if matches!(affinity, PeerAffinity::High) => {
+                Some(PeerInfo { affinity, .. })
+                    if matches!(affinity, PeerAffinity::High | PeerAffinity::Allowed) =>
+                {
                     // Do nothing, let the connection through
                 }
                 Some(PeerInfo { affinity, .. }) if matches!(affinity, PeerAffinity::Never) => {
@@ -374,7 +376,7 @@ impl ConnectionManager {
             known_peers
                 .values()
                 .filter(|peer_info| {
-                    !matches!(peer_info.affinity, PeerAffinity::Never)
+                    matches!(peer_info.affinity, PeerAffinity::High)
                     && peer_info.peer_id != self.endpoint.peer_id() // We don't dial ourself
                     && !peer_info.address.is_empty() // The peer has an address we can dial
                     && !active_peers.contains(&peer_info.peer_id) // The node is not already connected.

--- a/crates/anemo/src/types/mod.rs
+++ b/crates/anemo/src/types/mod.rs
@@ -47,8 +47,9 @@ pub mod header {
 pub enum PeerAffinity {
     /// Always attempt to maintain a connection with this Peer.
     High,
+    /// Not proactively attempt to estlish a connection but always accept inbound connection requests.
+    Allowed,
     /// Never attempt to maintain a connection with this Peer.
-    ///
     /// Inbound connection requests from these Peers are rejected.
     Never,
 }


### PR DESCRIPTION
Add `PeerAffinitiy::Allowlisted`:
1. it will income connections to bypass the max_concurrency limit, just as `PeerAffinity::High` does.
2. however peers with this affinity will not be proactively asked to establish connections in the background.