### PR TITLE
Use BTreeMap for deterministic drop order

### DIFF
--- a/crates/anemo/src/network/connection_manager.rs
+++ b/crates/anemo/src/network/connection_manager.rs
@@ -250,11 +250,16 @@ impl ConnectionManager {
             // TODO close the connection explicitly with a reason once we have machine
             // readable errors. See https://github.com/MystenLabs/anemo/issues/13 for more info.
             match known_peers.get(&connection.peer_id()) {
-                Some(PeerInfo { affinity: PeerAffinity::High | PeerAffinity::Allowed, .. }) =>
-                {
+                Some(PeerInfo {
+                    affinity: PeerAffinity::High | PeerAffinity::Allowed,
+                    ..
+                }) => {
                     // Do nothing, let the connection through
                 }
-                Some(PeerInfo { affinity: PeerAffinity::Never, .. }) => {
+                Some(PeerInfo {
+                    affinity: PeerAffinity::Never,
+                    ..
+                }) => {
                     return Err(anyhow::anyhow!(
                         "rejecting connection from peer {} due to having PeerAffinity::Never",
                         connection.peer_id()

--- a/crates/anemo/src/network/connection_manager.rs
+++ b/crates/anemo/src/network/connection_manager.rs
@@ -250,12 +250,11 @@ impl ConnectionManager {
             // TODO close the connection explicitly with a reason once we have machine
             // readable errors. See https://github.com/MystenLabs/anemo/issues/13 for more info.
             match known_peers.get(&connection.peer_id()) {
-                Some(PeerInfo { affinity, .. })
-                    if matches!(affinity, PeerAffinity::High | PeerAffinity::Allowed) =>
+                Some(PeerInfo { affinity: PeerAffinity::High | PeerAffinity::Allowed, .. }) =>
                 {
                     // Do nothing, let the connection through
                 }
-                Some(PeerInfo { affinity, .. }) if matches!(affinity, PeerAffinity::Never) => {
+                Some(PeerInfo { affinity: PeerAffinity::Never, .. }) => {
                     return Err(anyhow::anyhow!(
                         "rejecting connection from peer {} due to having PeerAffinity::Never",
                         connection.peer_id()

--- a/crates/anemo/src/routing/mod.rs
+++ b/crates/anemo/src/routing/mod.rs
@@ -1,6 +1,11 @@
 use crate::{Request, Response};
 use bytes::Bytes;
-use std::{collections::HashMap, convert::Infallible, fmt, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    convert::Infallible,
+    fmt,
+    sync::Arc,
+};
 use tower::{
     util::{BoxCloneService, Oneshot},
     Service,
@@ -30,7 +35,7 @@ impl RouteId {
 /// The router type for composing handlers and services.
 #[derive(Clone)]
 pub struct Router {
-    routes: HashMap<RouteId, Route>,
+    routes: BTreeMap<RouteId, Route>,
     matcher: RouteMatcher,
     fallback: Route,
 }


### PR DESCRIPTION
Because of the use of the static ROUTE_ID counter, the internal
ordering of the HashMap depends on when the routes are added to the
Router. Routes can cause arbitrary code to run when they are dropped,
so this is an unwanted source of non determinism. (Even controlling
the HashMap's RandomState will not help in this case).

A BTreeMap guarantees routes are dropped in the order they were created,
and. I also suspect it will be no slower (and maybe faster) for small
numbers of routes (the common case). This is not performance critical
code in any case.
