### PR TITLE
Add KnownPeers batch_update

### DIFF
--- a/crates/anemo/src/network/connection_manager.rs
+++ b/crates/anemo/src/network/connection_manager.rs
@@ -743,6 +743,20 @@ impl KnownPeers {
         self.inner_mut().insert(peer_info.peer_id, peer_info)
     }
 
+    pub fn batch_update<'a>(
+        &'a self,
+        to_remove: impl Iterator<Item = &'a PeerId>,
+        to_insert: impl Iterator<Item = PeerInfo>,
+    ) {
+        let mut inner = self.inner_mut();
+        to_remove.for_each(|peer_id| {
+            let _ = inner.remove(peer_id);
+        });
+        to_insert.for_each(|peer_info| {
+            let _ = inner.insert(peer_info.peer_id, peer_info);
+        });
+    }
+
     fn inner(&self) -> std::sync::RwLockReadGuard<'_, HashMap<PeerId, PeerInfo>> {
         self.0.read().unwrap()
     }

--- a/crates/anemo/src/network/connection_manager.rs
+++ b/crates/anemo/src/network/connection_manager.rs
@@ -747,14 +747,13 @@ impl KnownPeers {
         &'a self,
         to_remove: impl Iterator<Item = &'a PeerId>,
         to_insert: impl Iterator<Item = PeerInfo>,
-    ) {
+    ) -> (Vec<Option<PeerInfo>>, Vec<Option<PeerInfo>>) {
         let mut inner = self.inner_mut();
-        to_remove.for_each(|peer_id| {
-            let _ = inner.remove(peer_id);
-        });
-        to_insert.for_each(|peer_info| {
-            let _ = inner.insert(peer_info.peer_id, peer_info);
-        });
+        let removed = to_remove.map(|peer_id| inner.remove(peer_id)).collect();
+        let inserted = to_insert
+            .map(|peer_info| inner.insert(peer_info.peer_id, peer_info))
+            .collect();
+        (removed, inserted)
     }
 
     fn inner(&self) -> std::sync::RwLockReadGuard<'_, HashMap<PeerId, PeerInfo>> {

--- a/crates/anemo/src/network/connection_manager.rs
+++ b/crates/anemo/src/network/connection_manager.rs
@@ -744,7 +744,7 @@ impl KnownPeers {
     }
 
     pub fn batch_update<'a>(
-        &'a self,
+        &self,
         to_remove: impl Iterator<Item = &'a PeerId>,
         to_insert: impl Iterator<Item = PeerInfo>,
     ) -> (Vec<Option<PeerInfo>>, Vec<Option<PeerInfo>>) {


### PR DESCRIPTION
This PR adds a `batch_update` method to `KnownPeers` so that it's possible to atomically update known peers set with multiple values. With the current API we need to acquire a write lock multiple times and the operation is not atomic. The alternative would be to add `pub fn update<F: FnMut(&mut HashMap<PeerId, PeerInfo>)>(&self, f: F)` that would expose the internal `HashMap` which might be a breaking change in the future.