### PR TITLE
Fix panic while unwrapping Err value

### DIFF
--- a/crates/anemo/src/network/connection_manager.rs
+++ b/crates/anemo/src/network/connection_manager.rs
@@ -148,7 +148,18 @@ impl ConnectionManager {
                     }
                 },
                 Some(connecting_output) = self.pending_connections.join_next() => {
-                    self.handle_connecting_result(connecting_output.unwrap());
+                    match connecting_output {
+                        Ok(out) => {
+                            self.handle_connecting_result(out);
+                        },
+                        Err(e) => {
+                            if e.is_cancelled() {
+                                debug!("Pending connection cancelled");
+                            } else if e.is_panic() {
+                                std::panic::resume_unwind(e.into_panic());
+                            }
+                        },
+                    }
                 },
                 Some(connection_handler_output) = self.connection_handlers.join_next() => {
                     // If a task panics, just propagate it


### PR DESCRIPTION
This PR fixes a panic caused by unwrap [here](https://github.com/iotaledger/anemo/blob/main/crates/anemo/src/network/connection_manager.rs#L151). When tokio runtime is dropped without properly shutting down the Network, a pending connection may be cancelled before ConnectionManager is shut down in which case there is nothing to do, or panic in which case panic should be propagated.
